### PR TITLE
Bump dependencies to allow `containers-0.8`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@
 name: Build
 on:
   workflow_dispatch:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     types:
       - synchronize

--- a/lib/delta-types/delta-types.cabal
+++ b/lib/delta-types/delta-types.cabal
@@ -67,7 +67,7 @@ library
   hs-source-dirs:   src
   build-depends:
     , base >= 4.14 && < 5
-    , containers >= 0.5 && < 0.8
+    , containers >= 0.5 && < 0.9
     , semigroupoids >= 6.0.1 && < 6.1
   exposed-modules:
     Data.Delta


### PR DESCRIPTION
This pull request bumps the dependencies in `delta-types.cabal` to allow `containers-0.8`.