### PR TITLE
Remove re-export of `Semigroupoid` from `Data.Delta.Embedding`

### DIFF
--- a/lib/delta-types/src/Data/Delta.hs
+++ b/lib/delta-types/src/Data/Delta.hs
@@ -31,6 +31,8 @@ module Data.Delta (
 
     -- | Embeddings of delta types and helper functions.
     , module Data.Delta.Embedding
+
+    -- | Re-export "Data.Semigroupoid" for convenience.
     , module Data.Semigroupoid
     ) where
 

--- a/lib/delta-types/src/Data/Delta/Embedding.hs
+++ b/lib/delta-types/src/Data/Delta/Embedding.hs
@@ -14,7 +14,6 @@ Embeddings of delta types.
 module Data.Delta.Embedding (
     -- $Embedding
       Embedding
-    , module Data.Semigroupoid
     , Embedding' (..)
     , mkEmbedding
     , fromEmbedding


### PR DESCRIPTION
This pull request removes the re-export of `Data.Semigroupoid` from the child module `Data.Delta.Embedding`. We keep the re-export from the parent module `Data.Delta`.

The idea is that the concern of the parent module is to make both specific functionality and related functionality convenient to use, while the child modules are only concerned with providing specific functionality.